### PR TITLE
Fix installation configuration step

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Installation
     'dtomvan/xpm.xplr',
     { 'dtomvan/extra-icons.xplr',
         after = function()
-            xplr.config.general.table.row.cols[1] = { format = "custom.icons_dtomvan_col_1" }
+            xplr.config.general.table.row.cols[2] = { format = "custom.icons_dtomvan_col_1" }
         end
     },
   }


### PR DESCRIPTION
The instructions in the README have the wrong index. Here's what it looked like with index 1:
![image](https://user-images.githubusercontent.com/34889224/172180874-7535fe4d-2fab-4372-a695-5cbc400265c2.png)

Here's what it looks like with index 2:
![image](https://user-images.githubusercontent.com/34889224/172181011-5bf5e9e2-a62f-4e77-9eb5-2836a9762b5b.png)

I'm not actually very familiar with lua but I think this is correct.